### PR TITLE
Load wait URLs list from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,17 @@ Dockerize gives you the ability to wait for services on a specified protocol (`f
 $ dockerize -wait tcp://db:5432 -wait http://web:80 -wait file:///tmp/generated-file
 ```
 
+Wich is equivalend of using the flag `-from-env` with each url defined in an environment variable named `DOCKERIZE_WAIT<int>`:
+
+```
+$ export DOCKERIZE_WAIT1="http://web:80"
+$ export DOCKERIZE_WAIT2="tcp://db:5432"
+$ export DOCKERIZE_WAIT3="file:///tmp/generated-file"
+
+$ dockerize -wait-from-env
+```
+
+
 ### Timeout
 
 You can optionally specify how long to wait for the services to become available by using the `-timeout #` argument (Default: 10 seconds).  If the timeout is reached and the service is still not available, the process exits with status code 123.

--- a/env.go
+++ b/env.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"regexp"
 	"strings"
 )
 
@@ -22,4 +23,21 @@ func getEnv() map[string]string {
 		env[parts[0]] = parts[1]
 	}
 	return env
+}
+
+func getWaitsFromEnv() *urlsFlag {
+	result := new(urlsFlag)
+
+	re, _ := regexp.Compile("^DOCKERIZE_WAIT[0-9]+=.+$")
+
+	for _, kv := range os.Environ() {
+		if re.MatchString(kv) {
+			parts := strings.SplitN(kv, "=", 2)
+			if err := result.Set(parts[1]); err != nil {
+				os.Exit(1)
+			}
+		}
+	}
+
+	return result
 }

--- a/flag.go
+++ b/flag.go
@@ -40,6 +40,12 @@ func (f *urlsFlag) Set(value string) error {
 	return nil
 }
 
+func (f *urlsFlag) Append(others *urlsFlag) {
+	for _, url := range *others {
+		*f = append(*f, url)
+	}
+}
+
 func (f urlsFlag) String() string {
 	urls := make([]string, len(f))
 	for i := range f {

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func init() { //nolint:gochecknoinits // By design.)
 	flag.Var(&cfg.tailStdout, "stdout", "file `path` to tail to stdout\ncan be passed multiple times")
 	flag.Var(&cfg.tailStderr, "stderr", "file `path` to tail to stderr\ncan be passed multiple times")
 	flag.IntVar(&cfg.exitCodeFatal, "exit-code", exitCodeFatal, "exit code for dockerize errors")
-	flag.BoolVar(&cfg.loadFromEnv, "from-env", false, "Load wait list from DOCKERIZE_WAIT<N>")
+	flag.BoolVar(&cfg.loadFromEnv, "wait-from-env", false, "Load wait list from DOCKERIZE_WAIT<N> env variables")
 
 	flag.Usage = usage
 }


### PR DESCRIPTION
Added the flag `-waits-from-env` that allows loading 'waiting' URLs from env variables with a name like `DOCKERIZE_WAIT<int>`.

The flag can be combined with `-wait` flag.