### PR TITLE
fix(ci): sync go version with Dockerfile

### DIFF
--- a/.github/workflows/CI&CD.yml
+++ b/.github/workflows/CI&CD.yml
@@ -8,7 +8,7 @@ on:
     branches: master
 
 env:
-  GO_VERSION: '1.18.4' # Also in Dockerfile.
+  GO_VERSION: '1.19.3' # Also in Dockerfile.
 
 jobs:
 


### PR DESCRIPTION
This is just a minor bug fix where the Dockerfile was updated to golang 1.19.3 but the CICD workflow was not.