### PR TITLE
fix: use aarch64 suffix instead of arm64

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -25,6 +25,7 @@ linux-armhf             linux   arm     6
 linux-aarch64           linux   arm64
 linux-ppc64le           linux   ppc64le
 darwin-x86_64           darwin  amd64
+darwin-arm64            darwin  arm64
 DIST
 
 ghr -u "$GH_USER" -r "$GH_REPO" -replace "$TAG" "$DIST_DIR"

--- a/scripts/release
+++ b/scripts/release
@@ -22,7 +22,7 @@ linux-x86_64            linux   amd64
 linux-386               linux   386
 linux-armel             linux   arm     5
 linux-armhf             linux   arm     6
-linux-arm64             linux   arm64
+linux-aarch64           linux   arm64
 linux-ppc64le           linux   ppc64le
 darwin-x86_64           darwin  amd64
 DIST


### PR DESCRIPTION
On Linux, arm64 architecture is commonly referred to as aarch64. The `uname -m` command returns the latter. As a result, the command suggested in the README to install dockerize doesn't work on this architecture.

This commit fixes this by renaming the release artifact from "linux-arm64" to "linux-aarch64". Thus, "$(uname -s)-$(uname -m)" will return the expected artifact name.

See also: https://stackoverflow.com/a/45125525

---

Note that this may be surprising to users currently expecting the `-arm64` suffix. If necessary, we can consider providing both artifacts, but that sounds wrong.