### PR TITLE
chore: only publish docker images for tagged versions

### DIFF
--- a/.github/workflows/CI&CD.yml
+++ b/.github/workflows/CI&CD.yml
@@ -83,18 +83,39 @@ jobs:
 
       - name: Upload to DockerHub Container Registry
         run: |
+          IMAGE_NAME="${{ secrets.CR_USER }}/$(basename ${GITHUB_REPOSITORY,,})"
+          PLATFORMS=(
+            "linux/386"
+            "linux/amd64"
+            "linux/arm/v6"
+            "linux/arm/v7"
+            "linux/arm64/v8"
+            "linux/ppc64le"
+            "linux/s390x"
+          )
+
           docker login -u '${{ secrets.CR_USER }}' -p '${{ secrets.CR_PAT }}'
-          if echo "$GITHUB_REF" | grep -q '^refs/tags/v'; then
-            TAG="${GITHUB_REF/refs\/tags\/v}"
-          else
-            TAG="latest"
+
+          TAGS=()
+          if echo "$GITHUB_REF" | grep -qE '^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            PATCH_VERSION="${GITHUB_REF/refs\/tags\/v}"
+            MINOR_VERSION="$(echo "${PATCH_VERSION}" | cut -d "." -f 1,2)"
+            MAJOR_VERSION="$(echo "${PATCH_VERSION}" | cut -d "." -f 1)"
+            TAGS+=(
+              "${IMAGE_NAME}:latest"
+              "${IMAGE_NAME}:${PATCH_VERSION}"
+              "${IMAGE_NAME}:${MINOR_VERSION}"
+              "${IMAGE_NAME}:${MAJOR_VERSION}"
+            )
           fi
-          IMAGE_TAG="${{ secrets.CR_USER }}/$(basename ${GITHUB_REPOSITORY,,}):${TAG}"
-          docker buildx build \
-            --platform linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x \
-            --tag "${IMAGE_TAG}" \
-            --push \
-            .
+
+          if [ "${#TAGS}" -ne 0 ]; then
+            docker buildx build \
+              --platform "$(IFS=, ; echo "${PLATFORMS[*]}")" \
+              --tag "$(IFS=, ; echo "${TAGS[*]}")" \
+              --push \
+              .
+          fi
 
       - run: echo -e "$GPG_KEY" | gpg --import
         if: github.ref_type == 'tag'


### PR DESCRIPTION
  Previously, the following docker tags where created:  - `X.Y.Z` when building a git tag matching `vX.Y.Z` - `latest` in any other case  Starting from this commit, the following tags will be created:  - For git tags matching X.Y.Z the following docker tags will be created:   - `latest`   - `X`   - `X.Y`   - `X.Y.Z`  Other cases won't be tagged.

---

__edit: old comment below, please ignore__

Again, I was not able to test this commit end-to-end. Still, I tested that the script was generating an expected `buildx` command by manually specifying values for `GITHUB_REF`, `GITHUB_SHA` and `IMAGE_NAME`. It was tested with the following `GITHUB_REF`s:

- `refs/tags/v1.2.3` => `stable`, `1`, `1.2`, `1.2.3`
- `refs/tags/v1.2.3-beta` => `1.2.3-beta`
- `refs/heads/master` => `latest`, `<GITHUB_SHA>`
- `refs/heads/some-branch` => `<GITHUB_SHA>` (even though this is not a possible case yet because the workflow events are only set for the master branch and tags)