### PR TITLE
chore: release v0.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.1] - 2025-07-17
+
+### 📦️ Dependencies
+
+- **(deps)** Bump alpine from 3.22.0 to 3.22.1 by @dependabot[bot] in [#347]
+
+[0.23.1]: https://github.com/powerman/dockerize/compare/v0.23.0..v0.23.1
+[#347]: https://github.com/powerman/dockerize/pull/347
+
 ## [0.23.0] - 2025-07-14
 
 ### 🔔 Changed

--- a/README.md
+++ b/README.md
@@ -98,14 +98,14 @@ and then install
 (replace `linux-amd64` with your platform from the table above):
 
 ```sh
-curl -sfL https://github.com/powerman/dockerize/releases/download/v0.23.0/dockerize-v0.22.2-linux-amd64 | install /dev/stdin /usr/local/bin/dockerize
+curl -sfL https://github.com/powerman/dockerize/releases/download/v0.23.1/dockerize-v0.22.2-linux-amd64 | install /dev/stdin /usr/local/bin/dockerize
 ```
 
 If `curl` is not available (e.g. busybox base image)
 then you can use `wget`:
 
 ```sh
-wget -O - https://github.com/powerman/dockerize/releases/download/v0.23.0/dockerize-v0.22.2-linux-amd64 | install /dev/stdin /usr/local/bin/dockerize
+wget -O - https://github.com/powerman/dockerize/releases/download/v0.23.1/dockerize-v0.22.2-linux-amd64 | install /dev/stdin /usr/local/bin/dockerize
 ```
 
 ### Docker Installation
@@ -119,7 +119,7 @@ there are two recommended approaches:
    and available for all supported platforms:
 
    ```dockerfile
-   FROM powerman/dockerize:0.23.0
+   FROM powerman/dockerize:0.23.1
    ...
    ENTRYPOINT dockerize ...
    ```
@@ -128,7 +128,7 @@ there are two recommended approaches:
    using multi-stage build:
 
    ```dockerfile
-   FROM powerman/dockerize:0.23.0 AS dockerize
+   FROM powerman/dockerize:0.23.1 AS dockerize
    FROM node:18-slim
    ...
    COPY --from=dockerize /usr/local/bin/dockerize /usr/local/bin/


### PR DESCRIPTION

### 📦️ Dependencies

- **(deps)** Bump alpine from 3.22.0 to 3.22.1 by @dependabot[bot] in [#347]

[0.23.1]: https://github.com/powerman/dockerize/compare/v0.23.0..v0.23.1
[#347]: https://github.com/powerman/dockerize/pull/347