### PR TITLE
chore: release v0.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.1] - 2026-07-12
+
+### 📦️ Dependencies
+
+- **(deps)** Bump github.com/powerman/check v1.9.1→v1.13.0, github.com/rabbitmq/amqp091-go v1.11.0→v1.12.0 by @powerman in [e9847c6]
+- **(deps)** Bump alpine from 3.24.0 to 3.24.1 by @dependabot[bot] in [#387]
+
+[0.25.1]: https://github.com/powerman/dockerize/compare/v0.25.0..v0.25.1
+[e9847c6]: https://github.com/powerman/dockerize/commit/e9847c66d04057d5df43e280324c7497f4476e2e
+[#387]: https://github.com/powerman/dockerize/pull/387
+
 ## [0.25.0] - 2026-06-10
 
 ### 🚀 Added

--- a/README.md
+++ b/README.md
@@ -106,14 +106,14 @@ and then install
 (replace `linux-amd64` with your platform from the table above):
 
 ```sh
-curl -sfL https://github.com/powerman/dockerize/releases/download/v0.25.0/dockerize-v0.22.2-linux-amd64 | install /dev/stdin /usr/local/bin/dockerize
+curl -sfL https://github.com/powerman/dockerize/releases/download/v0.25.1/dockerize-v0.22.2-linux-amd64 | install /dev/stdin /usr/local/bin/dockerize
 ```
 
 If `curl` is not available (e.g. busybox base image)
 then you can use `wget`:
 
 ```sh
-wget -O - https://github.com/powerman/dockerize/releases/download/v0.25.0/dockerize-v0.22.2-linux-amd64 | install /dev/stdin /usr/local/bin/dockerize
+wget -O - https://github.com/powerman/dockerize/releases/download/v0.25.1/dockerize-v0.22.2-linux-amd64 | install /dev/stdin /usr/local/bin/dockerize
 ```
 
 ### Docker Installation
@@ -127,7 +127,7 @@ there are two recommended approaches:
    and available for all supported platforms:
 
    ```dockerfile
-   FROM powerman/dockerize:0.25.0
+   FROM powerman/dockerize:0.25.1
    ...
    ENTRYPOINT dockerize ...
    ```
@@ -136,7 +136,7 @@ there are two recommended approaches:
    using multi-stage build:
 
    ```dockerfile
-   FROM powerman/dockerize:0.25.0 AS dockerize
+   FROM powerman/dockerize:0.25.1 AS dockerize
    FROM node:18-slim
    ...
    COPY --from=dockerize /usr/local/bin/dockerize /usr/local/bin/


### PR DESCRIPTION

### 📦️ Dependencies

- **(deps)** Bump github.com/powerman/check v1.9.1→v1.13.0, github.com/rabbitmq/amqp091-go v1.11.0→v1.12.0 by @powerman in [e9847c6]
- **(deps)** Bump alpine from 3.24.0 to 3.24.1 by @dependabot[bot] in [#387]

[0.25.1]: https://github.com/powerman/dockerize/compare/v0.25.0..v0.25.1
[e9847c6]: https://github.com/powerman/dockerize/commit/e9847c66d04057d5df43e280324c7497f4476e2e
[#387]: https://github.com/powerman/dockerize/pull/387